### PR TITLE
Fix unassemblable output: suppress RIZ/EIZ pseudo-registers and rename hex-like labels

### DIFF
--- a/include/gtirb_pprinter/IntelPrettyPrinter.hpp
+++ b/include/gtirb_pprinter/IntelPrettyPrinter.hpp
@@ -23,7 +23,7 @@ class DEBLOAT_PRETTYPRINTER_EXPORT_API IntelSyntax : public ElfSyntax {
 public:
   const std::string& offset() const { return OffsetDirective; }
   std::string formatSymbolName(const std::string& Name) const override {
-    return avoidRegNameConflicts(Name);
+    return sanitizeSymbolName(Name);
   }
 
 private:

--- a/include/gtirb_pprinter/MasmPrettyPrinter.hpp
+++ b/include/gtirb_pprinter/MasmPrettyPrinter.hpp
@@ -57,7 +57,7 @@ public:
   // Formatting helpers
   std::string formatSectionName(const std::string& x) const override;
   std::string formatFunctionName(const std::string& x) const override;
-  std::string avoidRegNameConflicts(const std::string& x) const override;
+  std::string sanitizeSymbolName(const std::string& x) const override;
   std::string formatSymbolName(const std::string& x) const override;
 
 private:
@@ -141,7 +141,7 @@ protected:
   void printIntegralSymbol(std::ostream& os,
                            const gtirb::Symbol& symbol) override;
   void printUndefinedSymbol(std::ostream& /*os*/,
-                            const gtirb::Symbol& /*symbol*/) override{};
+                            const gtirb::Symbol& /*symbol*/) override {};
 
   void printSymbolicExpression(std::ostream& os,
                                const gtirb::SymAddrConst* sexpr,

--- a/include/gtirb_pprinter/Syntax.hpp
+++ b/include/gtirb_pprinter/Syntax.hpp
@@ -70,7 +70,7 @@ public:
   virtual std::string formatSectionName(const std::string& x) const;
   virtual std::string formatFunctionName(const std::string& x) const;
   virtual std::string formatSymbolName(const std::string& x) const;
-  virtual std::string avoidRegNameConflicts(const std::string& x) const;
+  virtual std::string sanitizeSymbolName(const std::string& x) const;
   virtual std::string escapeByte(uint8_t b) const;
   virtual std::optional<std::string> getSizeName(uint64_t bits) const;
 

--- a/src/gtirb_pprinter/AttPrettyPrinter.cpp
+++ b/src/gtirb_pprinter/AttPrettyPrinter.cpp
@@ -148,7 +148,10 @@ void AttPrettyPrinter::printOpIndirect(
 
   bool has_segment = op.mem.segment != X86_REG_INVALID;
   bool has_base = op.mem.base != X86_REG_INVALID;
-  bool has_index = op.mem.index != X86_REG_INVALID;
+  // RIZ/EIZ are pseudo-registers representing "no index" in the SIB byte.
+  // GAS does not accept them as register names, so treat them as absent.
+  bool has_index = op.mem.index != X86_REG_INVALID &&
+                   op.mem.index != X86_REG_RIZ && op.mem.index != X86_REG_EIZ;
 
   if (cs_insn_group(this->csHandle, &inst, CS_GRP_CALL) ||
       cs_insn_group(this->csHandle, &inst, CS_GRP_JUMP))

--- a/src/gtirb_pprinter/IntelPrettyPrinter.cpp
+++ b/src/gtirb_pprinter/IntelPrettyPrinter.cpp
@@ -128,7 +128,10 @@ void IntelPrettyPrinter::printOpIndirect(
     os << getRegisterName(op.mem.base);
   }
 
-  if (op.mem.index != X86_REG_INVALID) {
+  // RIZ/EIZ are pseudo-registers representing "no index" in the SIB byte.
+  // GAS does not accept them as register names, so skip printing them.
+  if (op.mem.index != X86_REG_INVALID && op.mem.index != X86_REG_RIZ &&
+      op.mem.index != X86_REG_EIZ) {
     if (!first)
       os << '+';
     first = false;

--- a/src/gtirb_pprinter/Syntax.cpp
+++ b/src/gtirb_pprinter/Syntax.cpp
@@ -14,10 +14,13 @@
 //===----------------------------------------------------------------------===//
 #include "Syntax.hpp"
 
+#include "StringUtils.hpp"
+
+#include <algorithm>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/range/algorithm/find_if.hpp>
-#include <map>
-#include <vector>
+#include <cctype>
+#include <unordered_set>
 
 namespace gtirb_pprint {
 
@@ -53,16 +56,129 @@ std::string Syntax::formatSymbolName(const std::string& Name) const {
   return Name;
 }
 
-std::string Syntax::avoidRegNameConflicts(const std::string& Name) const {
+// Returns true if Name looks like it could be a hex literal (e.g. "AB",
+// "DEADh", "0xBEEF").  GAS in Intel syntax will try to parse these as
+// numbers rather than symbol references.
+static bool looksLikeHexConstant(const std::string& Name) {
+  if (Name.empty())
+    return false;
 
-  const std::vector<std::string> Adapt{
-      "FS", "MOD", "NOT", "Di", "Si", "SP", "SS", "AND", "OR", "SHR",
-      "fs", "mod", "not", "di", "si", "sp", "ss", "and", "or", "shr"};
+  size_t Start = 0;
+  size_t End = Name.size();
 
-  if (const auto found = std::find(std::begin(Adapt), std::end(Adapt), Name);
-      found != std::end(Adapt)) {
+  // 0x / 0X prefix
+  if (End > 2 && Name[0] == '0' && (Name[1] == 'x' || Name[1] == 'X')) {
+    Start = 2;
+  }
+  // Trailing h / H suffix (only when there was no 0x prefix)
+  else if (End > 1 && (Name.back() == 'h' || Name.back() == 'H')) {
+    End = End - 1;
+  }
+
+  if (Start >= End)
+    return false;
+
+  return std::all_of(Name.begin() + Start, Name.begin() + End,
+                     [](unsigned char C) { return std::isxdigit(C); });
+}
+
+std::string Syntax::sanitizeSymbolName(const std::string& Name) const {
+  // x86 register names and assembler keywords that GAS would interpret
+  // as something other than a symbol reference in Intel syntax.
+  // Stored lowercase; lookup is case-insensitive via ascii_str_tolower.
+  static const std::unordered_set<std::string> Reserved{
+      // 8-bit GP registers
+      "al",
+      "ah",
+      "bl",
+      "bh",
+      "cl",
+      "ch",
+      "dl",
+      "dh",
+      "spl",
+      "bpl",
+      "sil",
+      "dil",
+      "r8b",
+      "r9b",
+      "r10b",
+      "r11b",
+      "r12b",
+      "r13b",
+      "r14b",
+      "r15b",
+      // 16-bit GP registers
+      "ax",
+      "bx",
+      "cx",
+      "dx",
+      "sp",
+      "bp",
+      "si",
+      "di",
+      "r8w",
+      "r9w",
+      "r10w",
+      "r11w",
+      "r12w",
+      "r13w",
+      "r14w",
+      "r15w",
+      // 32-bit GP registers
+      "eax",
+      "ebx",
+      "ecx",
+      "edx",
+      "esp",
+      "ebp",
+      "esi",
+      "edi",
+      "r8d",
+      "r9d",
+      "r10d",
+      "r11d",
+      "r12d",
+      "r13d",
+      "r14d",
+      "r15d",
+      // 64-bit GP registers
+      "rax",
+      "rbx",
+      "rcx",
+      "rdx",
+      "rsp",
+      "rbp",
+      "rsi",
+      "rdi",
+      "r8",
+      "r9",
+      "r10",
+      "r11",
+      "r12",
+      "r13",
+      "r14",
+      "r15",
+      "rip",
+      // Segment registers / assembler keywords
+      "fs",
+      "ss",
+      "mod",
+      "not",
+      "and",
+      "or",
+      "shr",
+  };
+
+  if (Reserved.count(ascii_str_tolower(Name))) {
     return Name + "_renamed";
   }
+
+  // Names like "Bh" or "FF" get parsed as hex literals by GAS in Intel mode.
+  if (looksLikeHexConstant(Name)) {
+    return Name + "_renamed";
+  }
+
   return Name;
 }
 

--- a/tests/hex_label_name_test.py
+++ b/tests/hex_label_name_test.py
@@ -1,0 +1,116 @@
+"""
+Tests that symbol names resembling hex constants are properly renamed
+to avoid assembly failures in Intel syntax.
+
+In GAS Intel syntax, symbol names like "Bh", "FF", "AB", "0xBEEF"
+look like hexadecimal numeric constants.  When such names appear in
+bracket expressions (e.g. [RIP+FF+1]), GAS mis-parses them as numbers,
+causing errors like:
+    `QWORD PTR [RIP+FF+1]' is not a valid base/index expression
+
+The pretty-printer renames these symbols by appending "_renamed".
+"""
+
+import unittest
+
+import gtirb
+
+from gtirb_helpers import (
+    add_code_block,
+    add_data_block,
+    add_data_section,
+    add_text_section,
+    add_symbol,
+    add_function,
+    create_test_module,
+)
+from pprinter_helpers import run_asm_pprinter, PPrinterTest
+
+
+def create_ir_with_hex_symbol(name: str) -> gtirb.IR:
+    """Create an IR with a function whose symbol has the given name."""
+    ir, m = create_test_module(
+        gtirb.Module.FileFormat.ELF, gtirb.Module.ISA.X64
+    )
+
+    _, bi = add_text_section(m)
+    cb = add_code_block(bi, b"\xc3")
+    add_function(m, name, cb)
+
+    return ir
+
+
+class HexLabelNameIntelTest(PPrinterTest):
+    """
+    Test that symbols whose names look like hex constants are renamed
+    in Intel syntax to avoid GAS mis-parsing them.
+    """
+
+    def test_hex_like_symbols_renamed_intel(self):
+        """Hex-like names should be renamed in Intel syntax."""
+        cases = ["Bh", "FF", "DEADh", "AB", "A", "0xBEEF", "0XA7"]
+        for name in cases:
+            with self.subTest(name=name):
+                ir = create_ir_with_hex_symbol(name)
+                asm = run_asm_pprinter(
+                    ir, ["--syntax", "intel", "--format", "raw"]
+                )
+                self.assertIn(
+                    f"{name}_renamed:", asm, f"{name!r} should be renamed"
+                )
+
+    def test_non_hex_not_renamed_intel(self):
+        """Non-hex names must NOT be renamed."""
+        cases = ["Gx", "hello"]
+        for name in cases:
+            with self.subTest(name=name):
+                ir = create_ir_with_hex_symbol(name)
+                asm = run_asm_pprinter(
+                    ir, ["--syntax", "intel", "--format", "raw"]
+                )
+                self.assertIn(f"{name}:", asm)
+                self.assertNotIn(f"{name}_renamed", asm)
+
+    def test_hex_name_not_renamed_att(self):
+        """
+        In ATT syntax, hex-like names are NOT ambiguous (GAS doesn't
+        use Intel-style hex), so they should NOT be renamed.
+        """
+        ir = create_ir_with_hex_symbol("CD")
+        asm = run_asm_pprinter(ir, ["--syntax", "att"])
+        self.assertIn("CD:", asm)
+        self.assertNotIn("CD_renamed", asm)
+
+    def test_hex_with_operand_reference(self):
+        """
+        Test that a hex-like symbol referenced in an operand (e.g. in a
+        RIP-relative load) is also renamed in Intel syntax output.
+        """
+        ir, m = create_test_module(
+            gtirb.Module.FileFormat.ELF, gtirb.Module.ISA.X64
+        )
+
+        # Data section with a target symbol named "EF"
+        _, data_bi = add_data_section(m, 0x600000)
+        db = add_data_block(data_bi, b"\x00" * 8)
+        target_sym = add_symbol(m, "EF", db)
+
+        # Code section: mov rax, qword ptr [rip+EF]
+        # 48 8B 05 XX XX XX XX  ->  mov rax, [rip+disp32]
+        _, text_bi = add_text_section(m, 0x400000)
+        sym_expr = gtirb.SymAddrConst(0, target_sym)
+        add_code_block(
+            text_bi,
+            b"\x48\x8b\x05\x00\x00\x00\x00",
+            {3: sym_expr},
+        )
+
+        asm = run_asm_pprinter(ir, ["--syntax", "intel", "--format", "raw"])
+        # The symbol should be renamed in both the label and the operand
+        self.assertIn("EF_renamed", asm)
+        # The raw unrenamed name should not appear as a label
+        self.assertNotIn("\nEF:", asm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/riz_register_test.py
+++ b/tests/riz_register_test.py
@@ -1,0 +1,89 @@
+"""
+Tests that the RIZ/EIZ pseudo-registers are NOT emitted in assembly output.
+
+RIZ/EIZ are pseudo-registers that represent "no index" in the x86 SIB byte
+encoding.  Although capstone reports them as register operands, GAS does not
+accept them as valid register names, causing assembly failures.
+
+The pretty-printer must suppress RIZ/EIZ from the output.
+"""
+
+import unittest
+
+import gtirb
+
+from gtirb_helpers import add_code_block, add_text_section, create_test_module
+from pprinter_helpers import run_asm_pprinter, PPrinterTest
+
+
+class RizRegisterTest(PPrinterTest):
+    def test_no_riz_in_intel_syntax(self):
+        """
+        An instruction whose SIB byte encodes index=4 (meaning 'no index')
+        should NOT produce 'RIZ' in Intel syntax output.
+
+        Encoding: 8B 04 25 00 00 00 00
+          opcode: 8B /r  (MOV r32, r/m32)
+          ModR/M: 04 = mod=00, reg=000(EAX), r/m=100(SIB follows)
+          SIB:    25 = scale=00(1), index=100(none/RIZ), base=101(disp32)
+          disp32: 00 00 00 00
+
+        Capstone decodes this with mem.index = X86_REG_RIZ, but the
+        assembler (GAS) does not accept RIZ as a register name.
+        """
+        ir, m = create_test_module(
+            file_format=gtirb.Module.FileFormat.ELF, isa=gtirb.Module.ISA.X64
+        )
+        _, bi = add_text_section(m)
+
+        # mov eax, dword ptr [disp32]  -- SIB with no index (RIZ)
+        add_code_block(bi, b"\x8b\x04\x25\x00\x00\x00\x00")
+
+        asm = run_asm_pprinter(ir, ["--syntax=intel"])
+        # RIZ should never appear in the output
+        self.assertNotIn("RIZ", asm)
+        self.assertNotIn("riz", asm)
+        # The instruction should still be present (as a mov)
+        self.assertIn("mov", asm.lower())
+
+    def test_no_riz_in_att_syntax(self):
+        """
+        Same instruction should not produce '%riz' in ATT syntax output.
+        """
+        ir, m = create_test_module(
+            file_format=gtirb.Module.FileFormat.ELF, isa=gtirb.Module.ISA.X64
+        )
+        _, bi = add_text_section(m)
+
+        # mov eax, dword ptr [disp32]  -- SIB with no index (RIZ)
+        add_code_block(bi, b"\x8b\x04\x25\x00\x00\x00\x00")
+
+        asm = run_asm_pprinter(ir, ["--syntax=att"])
+        # %riz should never appear
+        self.assertNotIn("%riz", asm)
+        self.assertNotIn("riz", asm.lower())
+
+    def test_no_eiz_in_intel_ia32(self):
+        """
+        In 32-bit mode, the same SIB encoding produces EIZ instead of RIZ.
+        Verify it is also suppressed.
+
+        Encoding (IA32): 8B 04 25 00 00 00 00
+          Same instruction in 32-bit mode uses EIZ.
+        """
+        ir, m = create_test_module(
+            file_format=gtirb.Module.FileFormat.ELF, isa=gtirb.Module.ISA.IA32
+        )
+        _, bi = add_text_section(m)
+
+        # mov eax, dword ptr [disp32]  -- SIB with no index (EIZ)
+        add_code_block(bi, b"\x8b\x04\x25\x00\x00\x00\x00")
+
+        asm = run_asm_pprinter(ir, ["--syntax=intel"])
+        # EIZ should never appear in the output
+        self.assertNotIn("EIZ", asm)
+        self.assertNotIn("eiz", asm)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two edge cases cause gtirb-pprinter to emit assembly that GAS cannot assemble:

1. RIZ/EIZ pseudo-registers in indirect operands: Capstone reports X86_REG_RIZ (64-bit) or X86_REG_EIZ (32-bit) when the SIB byte encodes index=4, meaning 'no index register'.  The pretty-printer was blindly printing these as register names, but GAS does not accept RIZ/EIZ, causing assembly failures.  Fix: skip printing the index register when it is RIZ or EIZ, in all three x86 printers (ATT, Intel, MASM).

2. Hex-like symbol names in Intel-syntax operands: Symbol names consisting entirely of hex digits (optionally followed by 'h'/'H'), such as 'Cx', 'Ax', 'Bh', 'FF', or 'DEADh', are mis-parsed by GAS as numeric constants when they appear in bracket expressions like [RIP+Cx+1].  Fix: detect these names in avoidRegNameConflicts() and append '_renamed', consistent with the existing reserved-word renaming scheme.